### PR TITLE
Added support for partial class mocks.

### DIFF
--- a/Source/OCMock.xcodeproj/project.pbxproj
+++ b/Source/OCMock.xcodeproj/project.pbxproj
@@ -132,6 +132,10 @@
 		F081270F154F3EEF0083FD1A /* OCMockClassObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F081270C154F3EEF0083FD1A /* OCMockClassObject.h */; };
 		F0812710154F3EEF0083FD1A /* OCMockClassObject.m in Sources */ = {isa = PBXBuildFile; fileRef = F081270D154F3EEF0083FD1A /* OCMockClassObject.m */; };
 		F0812711154F3EEF0083FD1A /* OCMockClassObject.m in Sources */ = {isa = PBXBuildFile; fileRef = F081270D154F3EEF0083FD1A /* OCMockClassObject.m */; };
+		F08B88571688D62100C4FE44 /* OCPartialClassMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F08B88551688D62000C4FE44 /* OCPartialClassMockObject.h */; };
+		F08B88581688D62100C4FE44 /* OCPartialClassMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F08B88551688D62000C4FE44 /* OCPartialClassMockObject.h */; };
+		F08B88591688D62100C4FE44 /* OCPartialClassMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = F08B88561688D62100C4FE44 /* OCPartialClassMockObject.m */; };
+		F08B885B1688D62100C4FE44 /* OCPartialClassMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = F08B88561688D62100C4FE44 /* OCPartialClassMockObject.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -228,6 +232,8 @@
 		F08126FC154F07350083FD1A /* OCPartialMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCPartialMock.h; sourceTree = "<group>"; };
 		F081270C154F3EEF0083FD1A /* OCMockClassObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCMockClassObject.h; sourceTree = "<group>"; };
 		F081270D154F3EEF0083FD1A /* OCMockClassObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCMockClassObject.m; sourceTree = "<group>"; };
+		F08B88551688D62000C4FE44 /* OCPartialClassMockObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCPartialClassMockObject.h; sourceTree = "<group>"; };
+		F08B88561688D62100C4FE44 /* OCPartialClassMockObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCPartialClassMockObject.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -477,6 +483,8 @@
 				03B315AA146333BF0052CD09 /* OCPartialMockObject.m */,
 				03E6F056152FA60B0079EAF7 /* OCPartialMockClassObject.h */,
 				03E6F057152FA60B0079EAF7 /* OCPartialMockClassObject.m */,
+				F08B88551688D62000C4FE44 /* OCPartialClassMockObject.h */,
+				F08B88561688D62100C4FE44 /* OCPartialClassMockObject.m */,
 				03B315AB146333BF0052CD09 /* OCPartialMockRecorder.h */,
 				03B315AC146333BF0052CD09 /* OCPartialMockRecorder.m */,
 				03B3161D146334AD0052CD09 /* Invocation Handler */,
@@ -555,6 +563,7 @@
 				03B31613146333C00052CD09 /* OCProtocolMockObject.h in Headers */,
 				03E6F058152FA60B0079EAF7 /* OCPartialMockClassObject.h in Headers */,
 				F081270E154F3EEF0083FD1A /* OCMockClassObject.h in Headers */,
+				F08B88571688D62100C4FE44 /* OCPartialClassMockObject.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -592,6 +601,7 @@
 				03B316441463350E0052CD09 /* OCObserverMockObjectTests.h in Headers */,
 				03E6F059152FA60B0079EAF7 /* OCPartialMockClassObject.h in Headers */,
 				F081270F154F3EEF0083FD1A /* OCMockClassObject.h in Headers */,
+				F08B88581688D62100C4FE44 /* OCPartialClassMockObject.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -797,6 +807,7 @@
 				03B31615146333C00052CD09 /* OCProtocolMockObject.m in Sources */,
 				03E6F05A152FA60B0079EAF7 /* OCPartialMockClassObject.m in Sources */,
 				F0812710154F3EEF0083FD1A /* OCMockClassObject.m in Sources */,
+				F08B88591688D62100C4FE44 /* OCPartialClassMockObject.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -840,6 +851,7 @@
 				03B31617146333C00052CD09 /* OCProtocolMockObject.m in Sources */,
 				03E6F05B152FA60B0079EAF7 /* OCPartialMockClassObject.m in Sources */,
 				F0812711154F3EEF0083FD1A /* OCMockClassObject.m in Sources */,
+				F08B885B1688D62100C4FE44 /* OCPartialClassMockObject.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/OCMock/OCMockObject.h
+++ b/Source/OCMock/OCMockObject.h
@@ -23,6 +23,19 @@
 // for a given Class at any one time
 + (id)partialMockForClassObject:(Class)aClass;
 
+// Partial class mocks are used to indirectly handle invocations
+// on ALL instances of the mocked Class.
+// They are to be used, instead of partial object mocks,
+// where the identities of individual instances are unknown or unimportant.
+//
+// Partial class mocks may NOT be used directly--as instances of the mocked Class--
+// because there is no single "real object" to which to forward unrecorded
+// and "andForwardToRealObject"-handled invocations from a directly-used mock.
+
+// There may only exist one partial class mock
+// for a given Class at any one time.
++ (id)partialMockForClass:(Class)aClass;
+
 + (id)niceMockForClass:(Class)aClass;
 + (id)niceMockForClassObject:(Class)aClass;
 + (id)niceMockForProtocol:(Protocol *)aProtocol;

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -9,6 +9,7 @@
 #import "OCProtocolMockObject.h"
 #import "OCPartialMockObject.h"
 #import "OCPartialMockClassObject.h"
+#import "OCPartialClassMockObject.h"
 #import "OCObserverMockObject.h"
 #import <OCMock/OCMockRecorder.h>
 #import "NSInvocation+OCMAdditions.h"
@@ -56,6 +57,10 @@
 
 + (id)partialMockForClassObject:(Class)aClass {
     return [[[OCPartialMockClassObject alloc] initWithClass:aClass] autorelease];
+}
+
++ (id)partialMockForClass:(Class)aClass {
+    return [[[OCPartialClassMockObject alloc] initWithClass:aClass] autorelease];
 }
 
 + (id)niceMockForClass:(Class)aClass

--- a/Source/OCMock/OCPartialClassMockObject.h
+++ b/Source/OCMock/OCPartialClassMockObject.h
@@ -1,0 +1,14 @@
+//---------------------------------------------------------------------------------------
+//  $Id$
+//  Copyright (c) 2012 by Mulle Kybernetik. See License file for details.
+//---------------------------------------------------------------------------------------
+
+#import "OCMockObject.h"
+
+#import "OCPartialMock.h"
+
+@interface OCPartialClassMockObject : OCMockObject <OCPartialMock>
+
+- (instancetype)initWithClass:(Class)aClass;
+
+@end

--- a/Source/OCMock/OCPartialClassMockObject.m
+++ b/Source/OCMock/OCPartialClassMockObject.m
@@ -1,0 +1,197 @@
+//---------------------------------------------------------------------------------------
+//  $Id$
+//  Copyright (c) 2012 by Mulle Kybernetik. See License file for details.
+//---------------------------------------------------------------------------------------
+
+#import "OCPartialClassMockObject.h"
+#import "OCPartialMockRecorder.h"
+
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+@implementation OCPartialClassMockObject {
+    Class _mockedClass;
+}
+
+#pragma mark  Mock table
+
+static NSMutableDictionary *mockTable;
+
++ (void)initialize
+{
+	if(self == [OCPartialClassMockObject class])
+		mockTable = [[NSMutableDictionary alloc] init];
+}
+
++ (void)rememberMock:(OCPartialClassMockObject *)mock forClass:(Class)aClass
+{
+    OCPartialClassMockObject *existingMock = [[mockTable objectForKey:[NSValue valueWithNonretainedObject:aClass]] nonretainedObjectValue];
+    if (existingMock != nil) {
+        [NSException raise:NSInternalInconsistencyException format:@"Class %@ is already being mocked.", NSStringFromClass(aClass)];
+    }
+	[mockTable setObject:[NSValue valueWithNonretainedObject:mock] forKey:[NSValue valueWithNonretainedObject:aClass]];
+}
+
++ (void)forgetMockForClass:(Class)aClass
+{
+	[mockTable removeObjectForKey:[NSValue valueWithNonretainedObject:aClass]];
+}
+
++ (OCPartialClassMockObject *)existingMockForClass:(Class)aClass
+{
+	OCPartialClassMockObject *mock = [[mockTable objectForKey:[NSValue valueWithNonretainedObject:aClass]] nonretainedObjectValue];
+	if(mock == nil)
+		[NSException raise:NSInternalInconsistencyException format:@"No mock for class %@", NSStringFromClass(aClass)];
+	return mock;
+}
+
+
+#pragma mark - Initialisers, description, accessors, etc.
+
+- (instancetype)initWithClass:(Class)aClass
+{
+    self = [super init];
+    if (self) {
+        [[self class] rememberMock:self forClass:aClass];
+        [self setupClass:aClass];
+        _mockedClass = aClass;
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    if (_mockedClass) [self stopMocking];
+    [super dealloc];
+}
+
+- (NSString *)description
+{
+	return [NSString stringWithFormat:@"OCPartialClassMockObject[%@]", NSStringFromClass(_mockedClass)];
+}
+
+#pragma mark - Mock configuration
+
+- (id)realObject {
+    // A partial class mock doesn't represent one particular object.
+    // This is why we cannot allow direct use of partial class mocks:
+    // because we would not be able to forward unrecorded and "andForwardToRealObject"-handled
+    // methods invoked directly on a partial class mock.
+    return nil;
+}
+
+- (void)stopMocking
+{
+    // We set the implementations of all the mocked methods back to the originals.
+    // We detect which methods were mocked, and retrieve the original IMPs,
+    // by looking through the class' methods for names prefixed with our alias.
+    unsigned int numMethods;
+    Method *methodList = class_copyMethodList(_mockedClass, &numMethods);
+    for (int methodIndex = 0; methodIndex < numMethods; methodIndex++) {
+        Method method = methodList[methodIndex];
+        SEL methodSelector = method_getName(method);
+        NSString *methodName = NSStringFromSelector(methodSelector);
+
+        if ([methodName hasPrefix:OCMRealMethodAliasPrefix]) {
+            NSString *mockedMethodName = [methodName substringFromIndex:[OCMRealMethodAliasPrefix length]];
+            SEL mockedMethodSelector = NSSelectorFromString(mockedMethodName);
+            IMP originalImp = method_getImplementation(method);
+            class_replaceMethod(_mockedClass, mockedMethodSelector, originalImp, method_getTypeEncoding(method));
+        }
+    }
+    free(methodList);
+
+    // Note: The runtime doesn't support us removing the aliased methods
+    // from the mocked class, so we can't completely clean up here.
+    // But it'll be ok if we mock this class again –
+    // class_addMethod will just return NO when we try to "re-add" the aliased methods.
+
+    [[self class] forgetMockForClass:_mockedClass];
+    _mockedClass = NULL;
+}
+
+// Route forwardInvocation: to ourselves so we get a chance
+// to handle recorded invocations on instances of the mocked class.
+- (void)setupClass:(Class)aClass
+{
+    SEL forwardInvocationSel = @selector(forwardInvocation:);
+    Method originalForwardInvocationMethod = class_getInstanceMethod(aClass, forwardInvocationSel);
+    IMP originalForwardInvocationImp = method_getImplementation(originalForwardInvocationMethod);
+
+	Method myForwardInvocationMethod = class_getInstanceMethod([self class], @selector(forwardInvocationForRealObject:));
+	IMP myForwardInvocationImp = method_getImplementation(myForwardInvocationMethod);
+	const char *forwardInvocationTypes = method_getTypeEncoding(myForwardInvocationMethod);
+	class_replaceMethod(aClass, forwardInvocationSel, myForwardInvocationImp, forwardInvocationTypes);
+
+    // Add an aliased method to save the original IMP
+    // so that we can reset forwardInvocation:'s implementation
+    // when we stop mocking.
+    NSString *aliasForwardInvocationName = [OCMRealMethodAliasPrefix stringByAppendingString:NSStringFromSelector(forwardInvocationSel)];
+	SEL aliasForwardInvocationSel = NSSelectorFromString(aliasForwardInvocationName);
+	class_addMethod(aClass, aliasForwardInvocationSel, originalForwardInvocationImp, method_getTypeEncoding(originalForwardInvocationMethod));
+}
+
+- (void)setupForwarderForSelector:(SEL)selector
+{
+	Method originalMethod = class_getInstanceMethod(_mockedClass, selector);
+    IMP originalImp = method_getImplementation(originalMethod);
+
+    // We must wish to handle invocations of selector ourselves,
+    // which we do by replacing the originalMethod's implementation
+    // with the runtime forwarding function _objc_msgForward(_stret).
+    // We will receive the invocations because we route forwardInvocation: to ourselves above.
+    char *methodReturnType = method_copyReturnType(originalMethod);
+    BOOL methodReturnsStruct = (methodReturnType && (strlen(methodReturnType) > 0) && methodReturnType[0] == '{');
+    free(methodReturnType);
+    IMP forwarderImp = (methodReturnsStruct ? (IMP)_objc_msgForward_stret : (IMP)_objc_msgForward);
+	class_replaceMethod(_mockedClass, method_getName(originalMethod), forwarderImp, method_getTypeEncoding(originalMethod));
+
+    // We add an aliased method to save the original IMP
+    // so that methods can be forwarded to instances
+    // and so that we can reset the method's implementation
+    // when we stop mocking.
+    NSString *aliasSelectorName = [OCMRealMethodAliasPrefix stringByAppendingString:NSStringFromSelector(selector)];
+	SEL aliasSelector = NSSelectorFromString(aliasSelectorName);
+	class_addMethod(_mockedClass, aliasSelector, originalImp, method_getTypeEncoding(originalMethod));
+}
+
+- (void)forwardInvocationForRealObject:(NSInvocation *)anInvocation
+{
+	// in here "self" is a reference to the real object, not the mock
+	OCPartialClassMockObject *mock = [OCPartialClassMockObject existingMockForClass:[self class]];
+	if([mock handleInvocation:anInvocation] == NO)
+		[NSException raise:NSInternalInconsistencyException
+                    format:@"Ended up in forwarder for %@ with unstubbed method %@",
+                             // we use [self description] because NSProxy does not implement the methods required to format self
+                            [self description], NSStringFromSelector([anInvocation selector])];
+}
+
+#pragma mark - Proxy API
+
+// NOTE: We implement methodSignatureForSelector for the benefit of the mock recorder,
+// but not respondsToSelector:
+// partial class mocks do NOT respond to the instance-method selectors of the mocked class,
+// as they may not be used directly (see -realObject, above).
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    return [_mockedClass instanceMethodSignatureForSelector:aSelector];
+}
+
+// We also override forwardInvocation: to throw an exception rather than handling the invocation,
+// for the same reason as above.
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+    [NSException raise:NSInternalInconsistencyException
+                format:@"Unrecognized message sent to %@: %@. Possible attempt to set-up and call method on partial class mock directly.",
+                         // we use [self description] because NSProxy does not implement the methods required to format self
+                        [self description], NSStringFromSelector([invocation selector])];
+}
+
+#pragma mark Overrides
+
+- (id)getNewRecorder
+{
+	return [[[OCPartialMockRecorder alloc] initWithSignatureResolver:self] autorelease];
+}
+
+@end


### PR DESCRIPTION
Partial class mocks allow functionality to be stubbed out across
ALL instances of a class. They are to be used, instead of partial object mocks,
where the identities of individual instances are unknown or unimportant.

They differ from the other partial object mock types, and from class mocks,
in that they cannot be used directly, as instances of the mocked class.
This is because there is no single "real object" to which to forward unrecorded
invocations and "andForwardToRealObject"-handled invocations from a
directly-used mock. For this reason, OCPartialClassMockObject does not
descend from OCClassMockObject.
