### PR TITLE
Partial mocks now forward stubbed, but non-matching, method calls

### DIFF
--- a/Source/OCMock/OCPartialClassMockObject.m
+++ b/Source/OCMock/OCPartialClassMockObject.m
@@ -207,14 +207,26 @@ static NSMutableDictionary *mockTable;
 	// in here "self" is a reference to a real object, not the mock
 	OCPartialClassMockObject *mock = [OCPartialClassMockObject existingMockForClass:[self class]];
 	if([mock handleInvocation:anInvocation] == NO) {
-        // try to let the real object handle the invocation, if it says it can
-        // --it's possible that it would have done so
-        // if we hadn't overridden its forwardInvocation:
-        if ([self respondsToSelector:[anInvocation selector]]) {
+        SEL invocationSelector = [anInvocation selector];
+
+        // try to let the real object handle the invocation, if it says it can.
+        // two cases:
+        //  1. this is a method of the real object (which we stubbed, but didn't handle
+        //     because e.g. the arguments didn't match)
+        if (class_respondsToSelector(object_getClass(self), invocationSelector)) {
+            NSString *aliasInvocationName = [OCMRealMethodAliasPrefix stringByAppendingString:NSStringFromSelector(invocationSelector)];
+            SEL aliasInvocationSelector = NSSelectorFromString(aliasInvocationName);
+            [anInvocation setSelector:aliasInvocationSelector];
+            [anInvocation invokeWithTarget:self];
+
+        //  2. this a method the real object would have forwarded if we hadn't overridden
+        //     its forwardInvocation:
+        } else if ([self methodSignatureForSelector:invocationSelector]) {
             SEL forwardInvocationSel = @selector(forwardInvocation:);
             NSString *aliasForwardInvocationName = [OCMRealMethodAliasPrefix stringByAppendingString:NSStringFromSelector(forwardInvocationSel)];
             SEL aliasForwardInvocationSel = NSSelectorFromString(aliasForwardInvocationName);
             [self performSelector:aliasForwardInvocationSel withObject:anInvocation];
+            
         } else {
             // no one handled the invocation
             [NSException raise:NSInternalInconsistencyException

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -24,6 +24,7 @@
 @interface TestClassThatCallsSelf : NSObject
 - (NSString *)method1;
 - (NSString *)method2;
+- (NSString *)method3:(NSString *)foo;
 @end
 
 @implementation TestClassThatCallsSelf
@@ -37,6 +38,10 @@
 - (NSString *)method2
 {
 	return @"Foo";
+}
+
+- (NSString *)method3:(NSString *)foo {
+    return [foo uppercaseString];
 }
 
 @end
@@ -1232,6 +1237,44 @@ static NSString *TestNotification = @"TestNotification";
 	[mock lowercaseString];
 	[mock expect];
 }
+
+
+- (void)testForwardsStubbedButNonmatchingMethodCallsToRealObjectWhenSetUpAndCalledOnMock
+{
+	TestClassThatCallsSelf *foo = [[[TestClassThatCallsSelf alloc] init] autorelease];
+	mock = [OCMockObject partialMockForObject:foo];
+    [[[mock stub] andReturn:@"BAR"] method3:@"foo"];
+    
+    STAssertEqualObjects(@"BAR", [mock method3:@"foo"], @"Should have stubbed method.");
+    
+    STAssertNoThrow([mock method3:@"baz"], @"Should not have thrown an exception.");
+    STAssertEqualObjects(@"BAZ", [mock method3:@"baz"], @"Should have called method on real object.");
+}
+
+- (void)testForwardsStubbedButNonmatchingMethodCallsToRealObjectWhenSetUpAndCalledOnRealObject
+{
+	TestClassThatCallsSelf *foo = [[[TestClassThatCallsSelf alloc] init] autorelease];
+	mock = [OCMockObject partialMockForObject:foo];
+    [[[mock stub] andReturn:@"BAR"] method3:@"foo"];
+
+    STAssertEqualObjects(@"BAR", [foo method3:@"foo"], @"Should have stubbed method.");
+
+    STAssertNoThrow([foo method3:@"baz"], @"Should not have thrown an exception.");
+    STAssertEqualObjects(@"BAZ", [foo method3:@"baz"], @"Should have called method on real object.");
+}
+
+- (void)testForwardsStubbedButNonmatchingMethodCallsToRealObjectWhenSetUpAndCalledOnInstance
+{
+	TestClassThatCallsSelf *foo = [[[TestClassThatCallsSelf alloc] init] autorelease];
+	mock = [OCMockObject partialMockForClass:[TestClassThatCallsSelf class]];
+    [[[mock stub] andReturn:@"BAR"] method3:@"foo"];
+
+    STAssertEqualObjects(@"BAR", [foo method3:@"foo"], @"Should have stubbed method.");
+
+    STAssertNoThrow([foo method3:@"baz"], @"Should not have thrown an exception.");
+    STAssertEqualObjects(@"BAZ", [foo method3:@"baz"], @"Should have called method on real object.");
+}
+
 
 - (void)testForwardsToMockWhenSetUpAndCalledOnMock
 {


### PR DESCRIPTION
to their real objects.

Whereas before they would only forward un-handled method calls
if those methods were not stubbed at all.
