### PR TITLE
Partial class object mocks now forward stubbed, but non-matching,

### DIFF
--- a/Source/OCMock/OCPartialMockClassObject.m
+++ b/Source/OCMock/OCPartialMockClassObject.m
@@ -150,9 +150,33 @@ static NSMutableDictionary *mockTable;
 {
 	// in here "self" is a reference to the real class, not the mock
 	OCPartialMockClassObject *mock = [OCPartialMockClassObject existingMockForClass:(Class)self];
-	if([mock handleInvocation:anInvocation] == NO)
-		[NSException raise:NSInternalInconsistencyException format:@"Ended up in forwarder for %@ with unstubbed method %@",
-		 [self class], NSStringFromSelector([anInvocation selector])];
+	if([mock handleInvocation:anInvocation] == NO) {
+        SEL invocationSelector = [anInvocation selector];
+
+        // try to let the real object handle the invocation, if it says it can.
+        // two cases:
+        //  1. this is a method of the real object (which we stubbed, but didn't handle
+        //     because e.g. the arguments didn't match)
+        if (class_respondsToSelector(object_getClass(self), invocationSelector)) {
+            NSString *aliasInvocationName = [OCMRealMethodAliasPrefix stringByAppendingString:NSStringFromSelector(invocationSelector)];
+            SEL aliasInvocationSelector = NSSelectorFromString(aliasInvocationName);
+            [anInvocation setSelector:aliasInvocationSelector];
+            [anInvocation invokeWithTarget:self];
+
+        //  2. this a method the real object would have forwarded if we hadn't overridden
+        //     its forwardInvocation:
+        } else if ([self methodSignatureForSelector:invocationSelector]) {
+            SEL forwardInvocationSel = @selector(forwardInvocation:);
+            NSString *aliasForwardInvocationName = [OCMRealMethodAliasPrefix stringByAppendingString:NSStringFromSelector(forwardInvocationSel)];
+            SEL aliasForwardInvocationSel = NSSelectorFromString(aliasForwardInvocationName);
+            [self performSelector:aliasForwardInvocationSel withObject:anInvocation];
+
+        } else {
+            // no one handled the invocation
+            [NSException raise:NSInternalInconsistencyException format:@"Ended up in forwarder for %@ with unstubbed method %@",
+             [self class], NSStringFromSelector([anInvocation selector])];
+        }
+    }
 }
 
 

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -51,6 +51,7 @@
 
 + (NSString *)method1;
 + (NSString *)method2;
++ (NSString *)method3:(NSString *)foo;
 
 @end
 
@@ -63,6 +64,10 @@
 
 + (NSString *)method2 {
     return [self method1];
+}
+
++ (NSString *)method3:(NSString *)foo {
+    return [foo uppercaseString];
 }
 
 @end
@@ -1261,6 +1266,26 @@ static NSString *TestNotification = @"TestNotification";
 
     STAssertNoThrow([foo method3:@"baz"], @"Should not have thrown an exception.");
     STAssertEqualObjects(@"BAZ", [foo method3:@"baz"], @"Should have called method on real object.");
+}
+
+- (void)testForwardsStubbedButNonmatchingMethodCallsToRealObjectWhenSetUpAndCalledOnMockClassObject {
+	mock = [OCMockObject partialMockForClassObject:[TestClassWithClassMethod class]];
+    [[[mock stub] andReturn:@"BAR"] method3:@"foo"];
+
+    STAssertEqualObjects(@"BAR", [mock method3:@"foo"], @"Should have stubbed method.");
+
+    STAssertNoThrow([mock method3:@"baz"], @"Should not have thrown an exception.");
+    STAssertEqualObjects(@"BAZ", [mock method3:@"baz"], @"Should have called method on real object.");
+}
+
+- (void)testForwardsStubbedButNonmatchingMethodCallsToRealObjectWhenSetUpAndCalledOnRealClass {
+	mock = [OCMockObject partialMockForClassObject:[TestClassWithClassMethod class]];
+    [[[mock stub] andReturn:@"BAR"] method3:@"foo"];
+
+    STAssertEqualObjects(@"BAR", [TestClassWithClassMethod method3:@"foo"], @"Should have stubbed method.");
+
+    STAssertNoThrow([TestClassWithClassMethod method3:@"baz"], @"Should not have thrown an exception.");
+    STAssertEqualObjects(@"BAZ", [TestClassWithClassMethod method3:@"baz"], @"Should have called method on real object.");
 }
 
 - (void)testForwardsStubbedButNonmatchingMethodCallsToRealObjectWhenSetUpAndCalledOnInstance


### PR DESCRIPTION
method calls to their real objects.

Whereas before they would only forward un-handled method calls
if those methods were not stubbed at all.

This was missed in 2089a408c860fe3bb86d14bfcfed482482a2ff45.
