### PR TITLE
64-bit cleanup: use %tu & %zd for formats

### DIFF
--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -162,8 +162,8 @@
 	}
 	if([expectations count] > 0)
 	{
-		[NSException raise:NSInternalInconsistencyException format:@"%@ : %lu expected methods were not invoked: %@", 
-			[self description], (unsigned long)[expectations count], [self _recorderDescriptions:YES]];
+		[NSException raise:NSInternalInconsistencyException format:@"%@ : %tu expected methods were not invoked: %@", 
+			[self description], [expectations count], [self _recorderDescriptions:YES]];
 	}
 	if([exceptions count] > 0)
 	{

--- a/Source/OCMock/OCObserverMockObject.m
+++ b/Source/OCMock/OCObserverMockObject.m
@@ -53,8 +53,8 @@
 	}
 	if([recorders count] > 0)
 	{
-		[NSException raise:NSInternalInconsistencyException format:@"%@ : %lu expected notifications were not observed.", 
-		 [self description], (unsigned long)[recorders count]];
+		[NSException raise:NSInternalInconsistencyException format:@"%@ : %tu expected notifications were not observed.",
+		 [self description], [recorders count]];
 	}
 }
 

--- a/Source/OCMockTests/NSInvocationOCMAdditionsTests.m
+++ b/Source/OCMockTests/NSInvocationOCMAdditionsTests.m
@@ -323,7 +323,7 @@
 	[invocation setArgument:&length atIndex:3];
 	
 	NSString *expected1 = [NSString stringWithFormat:@"initWithBytes:"];
-	NSString *expected2 = [NSString stringWithFormat:@"length:%lu", (unsigned long)length];
+	NSString *expected2 = [NSString stringWithFormat:@"length:%tu", length];
 	NSString *invocationDescription = [invocation invocationDescription];
 	STAssertTrue([invocationDescription rangeOfString:expected1].length > 0, @"");
 	STAssertTrue([invocationDescription rangeOfString:expected2].length > 0, @"");

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -475,7 +475,7 @@ static NSString *TestNotification = @"TestNotification";
 
 - (NSString *)valueForString:(NSString *)aString andMask:(NSStringCompareOptions)mask
 {
-	return [NSString stringWithFormat:@"[%@, %lu]", aString, (unsigned long)mask];
+	return [NSString stringWithFormat:@"[%@, %tu]", aString, mask];
 }
 
 - (void)testCallsAlternativeMethodAndPassesOriginalArgumentsAndReturnsValue


### PR DESCRIPTION
while the officially supported Apple position is to cast the value,
there are some circumstances in which this can result in a different
value being printed than is held.  this can be particularly troublesome
for values that are meant to be held as 64-bit IDs.

this solution is pretty widely accepted as a way to have a single
specifier for each solution that works on both 32-bit & 64-bit archs.
